### PR TITLE
Add Servo to AWFY's builder and puller.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ benchmarks/asmjs-apps/zlib/minigzipsh
 
 driver/awfy.config
 **/*-results/
+
+output/

--- a/slave/build.py
+++ b/slave/build.py
@@ -243,6 +243,26 @@ class V8Builder(Builder):
     def binary(self):
         return os.path.join(self.objdir(), 'd8')
 
+class ServoBuilder(Builder):
+    def __init__(self, config, folder):
+        super(ServoBuilder, self).__init__(config, folder);
+        # Some other config here
+    
+    def retrieveInfo(self):
+        info = {}
+        info["engine_type"] = "servo"
+        return info
+
+    def objdir(self):
+        return os.path.join(self.folder, 'target')
+
+    def binary(self):
+        return os.path.join(self.objdir(), 'release', 'servo')
+
+    def make(self):
+        args = [os.path.join('.', self.folder, 'mach'), 'build' ,'--release']
+        Run(args, self.env.get())
+
 def getBuilder(config, path):
     # fingerprint the known builders
     if os.path.exists(os.path.join(path, "js", "src")):
@@ -251,6 +271,8 @@ def getBuilder(config, path):
         return WebkitBuilder(config, path)
     if os.path.exists(os.path.join(path, "v8", "LICENSE.v8")):
         return V8Builder(config, path)
+    if os.path.exists(os.path.join(path, "mach")):
+        return ServoBuilder(config, path)
 
     raise Exception("Unknown builder")
 

--- a/slave/build.py
+++ b/slave/build.py
@@ -260,8 +260,16 @@ class ServoBuilder(Builder):
         return os.path.join(self.objdir(), 'release', 'servo')
 
     def make(self):
-        args = [os.path.join('.', self.folder, 'mach'), 'build' ,'--release']
-        Run(args, self.env.get())
+        # Remember cwd
+        cwd = os.getcwd()
+        # cd into servo's root directory. Requirement of 'mach build'
+        os.chdir(self.folder)
+        try:
+            args = [os.path.join('.', 'mach'), 'build' ,'--release']
+            Run(args, self.env.get())
+        finally:
+            # Go back to the cwd
+            os.chdir(cwd)
 
 def getBuilder(config, path):
     # fingerprint the known builders

--- a/slave/build.py
+++ b/slave/build.py
@@ -272,7 +272,7 @@ def getBuilder(config, path):
         return WebkitBuilder(config, path)
     if os.path.exists(os.path.join(path, "v8", "LICENSE.v8")):
         return V8Builder(config, path)
-    if os.path.exists(os.path.join(path, "mach")):
+    if os.path.exists(os.path.join(path, "components", "servo")):
         return ServoBuilder(config, path)
 
     raise Exception("Unknown builder")

--- a/slave/build.py
+++ b/slave/build.py
@@ -260,16 +260,9 @@ class ServoBuilder(Builder):
         return os.path.join(self.objdir(), 'release', 'servo')
 
     def make(self):
-        # Remember cwd
-        cwd = os.getcwd()
-        # cd into servo's root directory. Requirement of 'mach build'
-        os.chdir(self.folder)
-        try:
+        with utils.FolderChanger(self.folder):
             args = [os.path.join('.', 'mach'), 'build' ,'--release']
             Run(args, self.env.get())
-        finally:
-            # Go back to the cwd
-            os.chdir(cwd)
 
 def getBuilder(config, path):
     # fingerprint the known builders

--- a/slave/puller.py
+++ b/slave/puller.py
@@ -153,6 +153,8 @@ def getPuller(repo, path):
         repo = "http://hg.mozilla.org/integration/mozilla-inbound"
     elif repo == "webkit":
         repo = "https://svn.webkit.org/repository/webkit/trunk"
+    elif repo == "servo":
+        repo = "https://github.com/servo/servo.git"
 
     if "hg." in repo:
         return HG(repo, path)


### PR DESCRIPTION
Pull request for code review.
Now using `build.py`, one can pull and build servo from source.
Full Command: 

``` shell
python slave/build.py --source servo
```

Other command line flags remain the same as before.
