### PR TITLE
Add Servo Executor.

### DIFF
--- a/slave/build.py
+++ b/slave/build.py
@@ -262,6 +262,16 @@ class ServoBuilder(Builder):
             args = [os.path.join('.', 'mach'), 'build' ,'--release']
             Run(args, self.env.get())
 
+    def build(self, puller):
+        # Call parent's build
+        super(ServoBuilder, self).build(puller)
+        # Read info.json file back and modify only shell=False.
+        with open(os.path.join(self.folder, "info.json"),  'r+') as info_file:
+            info = json.load(info_file)
+            info["shell"] = False
+            info_file.seek(0)
+            json.dump(info, info_file)
+
 def getBuilder(config, path):
     # fingerprint the known builders
     if os.path.exists(os.path.join(path, "js", "src")):

--- a/slave/build.py
+++ b/slave/build.py
@@ -96,7 +96,9 @@ class Builder(object):
 
         info = self.retrieveInfo()
         info["revision"] = puller.identify()
-        info["shell"] = True
+        # Deafult 'shell' to True only if it isn't set yet!
+        if 'shell' not in info:
+            info["shell"] = True
         info["binary"] = os.path.abspath(self.binary())
 
         fp = open(os.path.join(self.folder, "info.json"), "w")
@@ -249,6 +251,7 @@ class ServoBuilder(Builder):
     def retrieveInfo(self):
         info = {}
         info["engine_type"] = "servo"
+        info['shell'] = False
         return info
 
     def objdir(self):
@@ -261,16 +264,6 @@ class ServoBuilder(Builder):
         with utils.FolderChanger(self.folder):
             args = [os.path.join('.', 'mach'), 'build' ,'--release']
             Run(args, self.env.get())
-
-    def build(self, puller):
-        # Call parent's build
-        super(ServoBuilder, self).build(puller)
-        # Read info.json file back and modify only shell=False.
-        with open(os.path.join(self.folder, "info.json"),  'r+') as info_file:
-            info = json.load(info_file)
-            info["shell"] = False
-            info_file.seek(0)
-            json.dump(info, info_file)
 
 def getBuilder(config, path):
     # fingerprint the known builders

--- a/slave/configs.py
+++ b/slave/configs.py
@@ -23,6 +23,8 @@ class Default(object):
             pass
         elif engine == "ie":
             pass
+        elif engine == "servo":
+            pass
         else:
             self.omit_ = True
 

--- a/slave/execute.py
+++ b/slave/execute.py
@@ -54,7 +54,8 @@ if options.mode_rules is None:
         "chrome,default:v8",
         "chrome,turbofan:v8-turbofan",
         "webkit,default:jsc",
-        "native,default:clang"
+        "native,default:clang",
+        "servo,default:servo"
     ]
 
 #TODO:remove

--- a/slave/executors.py
+++ b/slave/executors.py
@@ -4,7 +4,6 @@ import os
 import sys
 import json
 
-sys.path.insert(1, '../driver')
 import utils
 
 class ShellExecutor(object):

--- a/slave/server.py
+++ b/slave/server.py
@@ -20,6 +20,7 @@ class FakeHandler(SimpleHTTPRequestHandler):
 
         parsedParams = urlparse.urlparse(self.path)
         self.localBenchmark(parsedParams.query)
+        self.send_response(200)
 
     def do_POST(self):
         length = int(self.headers.getheader('content-length', 0))
@@ -29,6 +30,7 @@ class FakeHandler(SimpleHTTPRequestHandler):
             return
 
         self.localBenchmark(postdata)
+        self.send_response(200)
 
     def localBenchmark(self, query = None):
         if self.path.startswith("/submit"):


### PR DESCRIPTION
Adds executor for servo.
**Running Dromaeo Benchmark for Servo**:

``` shell
# Assuming pwd = slave/
# Pull & build Servo. Skip this if it's already built.
python build.py --source servo
# Run Dromaeo Benchmark for Servo
python execute.py -b remote.dromaeo
```

**Output:**
- [Summary](https://gist.github.com/dhananjay92/f3eef3c4c8caeaa9a6ce)
- [Results](https://gist.github.com/dhananjay92/848eabba5dfb2048ce04)

This works on Linux. `osx_mount_point` & `android_processname` are  missing for OSX and Android runners. I can add `android_processname` once I know how to get it. @jdm: If you know how to find it, just let me know. I have never run Servo on android, so it will also help if you could point me to some doc that explains how to run it on Android.

@h4writer: I modified the `server.py` so that it returns response every time. Because of [Issue # 7725](https://github.com/servo/servo/issues/7725), Servo keeps sending requests if server doesn't respond. Please let me know if [that](https://github.com/dhananjay92/arewefastyet/commit/cdd0dd41a125977dac428d2a80feb26c93dbba00) is correct way to return response.
